### PR TITLE
Update for SMAPI 3.0

### DIFF
--- a/BeeHouseFix/BeeHouseFix.csproj
+++ b/BeeHouseFix/BeeHouseFix.csproj
@@ -12,8 +12,6 @@
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -32,6 +30,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.2.0" />
+  </ItemGroup>
   <ItemGroup>
     <Reference Include="0Harmony, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -52,17 +53,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="manifest.json" />
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.2.0\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
-  </Target>
 </Project>

--- a/BeeHouseFix/BeeHouseFix.csproj
+++ b/BeeHouseFix/BeeHouseFix.csproj
@@ -34,9 +34,8 @@
     <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="0Harmony, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\BigSteam\steamapps\common\Stardew Valley\0Harmony.dll</HintPath>
+    <Reference Include="0Harmony">
+      <HintPath>$(GamePath)\smapi-internal\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/BeeHouseFix/ModEntry.cs
+++ b/BeeHouseFix/ModEntry.cs
@@ -4,7 +4,6 @@ using StardewValley;
 using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using StardewValley.TerrainFeatures;
-using Netcode;
 
 namespace BeeHouseFix
 {

--- a/BeeHouseFix/manifest.json
+++ b/BeeHouseFix/manifest.json
@@ -1,5 +1,5 @@
 ﻿{
-   "Name": "BeeHouseFix",
+   "Name": "Bee House Flower Range Fix",
    "Author": "KirbyLink",
    "Version": "1.1.0",
    "Description": "Fixes bug preventing top/bottom right tiles of bee house radius to not be checked for flowers.",

--- a/BeeHouseFix/manifest.json
+++ b/BeeHouseFix/manifest.json
@@ -4,7 +4,7 @@
    "Version": "1.1.0",
    "Description": "Fixes bug preventing top/bottom right tiles of bee house radius to not be checked for flowers.",
    "UniqueID": "kirbylink.beehousefix",
-   "EntryDll": "beehousefix.dll",
-   "MinimumApiVersion": "2.0",
+   "EntryDll": "BeeHouseFix.dll",
+   "MinimumApiVersion": "2.0.0",
    "UpdateKeys": ["Nexus:3013"]
 }

--- a/BeeHouseFix/packages.config
+++ b/BeeHouseFix/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.2.0" targetFramework="net461" />
-</packages>


### PR DESCRIPTION
This pull request...

* Updates the manifest for SMAPI 3.0 (the `EntryDll` value will be case-sensitive for Linux/Mac compatibility).
* Migrates to the new package reference format.
* Fixes a hardcoded assembly path for the Harmony reference.
* Tweaks the manifest name to match Nexus (_BeeHouseFix_ → _Bee House Flower Range Fix_).

Let me know if you want me to make any changes!